### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests & Code Quality
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/sr-857/AstraGuard-AI/security/code-scanning/3](https://github.com/sr-857/AstraGuard-AI/security/code-scanning/3)

In general, the fix is to explicitly set `permissions` for the `GITHUB_TOKEN` either at the root of the workflow (applies to all jobs) or per job, and limit them to the minimal scopes required. Since none of the jobs push commits, manage issues, or modify repo state, they only need read access to repository contents.

The best fix here without changing functionality is to add a single workflow-level `permissions:` block directly under the `name:` (before `on:`) specifying `contents: read`. All jobs (`test`, `security`, and `code-quality`) will inherit this setting, and no step requires broader permissions. No other lines in the file need modification.

Concretely: in `.github/workflows/tests.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Tests & Code Quality`) and before the existing `on:` block. No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
