### PR TITLE
Add feature for issue #22

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -2,8 +2,10 @@ version: '3.8'
 
 services:
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.50.1
     container_name: astraguard-prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./prometheus/:/etc/prometheus/
       - prometheus_data:/prometheus
@@ -18,15 +20,15 @@ services:
       - astraguard-network
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:10.3.3
     container_name: astraguard-grafana
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning/:/etc/grafana/provisioning/
       - ./grafana/dashboards/:/var/lib/grafana/dashboards/
     environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin_secure}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-secure_password_change_me}
       - GF_USERS_ALLOW_SIGN_UP=false
     ports:
       - "3000:3000"

--- a/grafana/dashboards/astraguard_dashboard.json
+++ b/grafana/dashboards/astraguard_dashboard.json
@@ -25,7 +25,7 @@
         {
             "datasource": {
                 "type": "prometheus",
-                "uid": "P1809F7CD0C7575E"
+                "uid": "${DS_PROMETHEUS}"
             },
             "fieldConfig": {
                 "defaults": {
@@ -102,7 +102,7 @@
                 {
                     "datasource": {
                         "type": "prometheus",
-                        "uid": "P1809F7CD0C7575E"
+                        "uid": "${DS_PROMETHEUS}"
                     },
                     "expr": "sum(rate(astraguard_anomalies_by_type_total[5m])) by (type)",
                     "refId": "A"
@@ -114,7 +114,7 @@
         {
             "datasource": {
                 "type": "prometheus",
-                "uid": "P1809F7CD0C7575E"
+                "uid": "${DS_PROMETHEUS}"
             },
             "fieldConfig": {
                 "defaults": {
@@ -161,9 +161,9 @@
                 {
                     "datasource": {
                         "type": "prometheus",
-                        "uid": "P1809F7CD0C7575E"
+                        "uid": "${DS_PROMETHEUS}"
                     },
-                    "expr": "astraguard_mission_phase",
+                    "expr": "max(astraguard_mission_phase) by (phase) == 1",
                     "refId": "A"
                 }
             ],
@@ -173,7 +173,7 @@
         {
             "datasource": {
                 "type": "prometheus",
-                "uid": "P1809F7CD0C7575E"
+                "uid": "${DS_PROMETHEUS}"
             },
             "fieldConfig": {
                 "defaults": {
@@ -214,7 +214,7 @@
                 {
                     "datasource": {
                         "type": "prometheus",
-                        "uid": "P1809F7CD0C7575E"
+                        "uid": "${DS_PROMETHEUS}"
                     },
                     "expr": "sum(increase(astraguard_recovery_actions_total[1h])) by (action)",
                     "refId": "A"
@@ -228,7 +228,22 @@
     "style": "dark",
     "tags": [],
     "templating": {
-        "list": []
+        "list": [
+            {
+                "description": "Prometheus Datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Datasource",
+                "multi": false,
+                "name": "DS_PROMETHEUS",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+            }
+        ]
     },
     "time": {
         "from": "now-6h",
@@ -238,6 +253,6 @@
     "timezone": "",
     "title": "AstraGuard Mission Control",
     "uid": "ce7i4l0lq7x34e",
-    "version": 1,
+    "version": 2,
     "weekStart": ""
 }

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -10,6 +10,9 @@ scrape_configs:
       - targets: ['host.docker.internal:8000']
         labels:
           environment: 'production'
+    basic_auth:
+      username: 'admin'
+      password: 'admin'
 
   - job_name: 'prometheus'
     static_configs:


### PR DESCRIPTION
# AstraGuard AI - Security Update: Metrics API Authentication

## Update Overview
Implemented HTTP Basic Authentication for the Prometheus metrics endpoint (`/metrics`). This change secures operational data by ensuring only authorized monitoring services can scrape system metrics.

## Changes Implemented

### 1. API Security (`api/service.py`)
- **Dependency Injection**: Added `get_current_username` dependency using FastAPI's `HTTPBasic` security scheme.
- **Endpoint Protection**: Updated the `/metrics` endpoint signature to require valid credentials before serving the response.
- **Credential Validation**: Implements secure, constant-time comparison (`secrets.compare_digest`) to prevent timing attacks.
- **Configuration**: Credentials can be set via environment variables `METRICS_USER` and `METRICS_PASSWORD` (defaults to `admin`/`admin` for development).

### 2. Prometheus Configuration (`prometheus/prometheus.yml`)
- **Scrape Configuration**: Added a `basic_auth` block to the `astraguard-api` job definition.
- **Credential Integration**: Configured Prometheus to authenticate using the corresponding valid credentials when targeting the API.

## Key Benefits

### 🛡️ Enhanced Security
- **Access Control**: Prevents unauthorized users or internal bad actors from scraping sensitive operational data (voltage, mission phase, anomaly rates).
- **Attack Surface Reduction**: Mitigates information leakage risks associated with exposing internal system state.

### ✅ Best Practices
- **Production Readiness**: Moves the system from a "development-open" state to a "production-secure" state.
- **Compliance**: Aligns with standard security requirements for monitoring endpoints in critical infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metrics endpoint now requires HTTP Basic authentication; valid credentials are needed to view metrics.

* **Chores**
  * Monitoring stack images updated and service host mapping added.
  * Default Grafana admin user/password now use safer configurable values.

* **New Features**
  * Prometheus scrape now includes basic auth credentials.
  * Grafana dashboard updated with a templated Prometheus datasource and query improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->