### PR TITLE
Add Code of Conduct for project contributors

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -49,7 +49,6 @@ The following behaviors are not tolerated:
 If you experience or witness behavior that violates this Code of Conduct:
 
 Report it confidentially via:
-
   - GitHub Issues (if appropriate), or
   - Direct contact with project maintainers (listed in README / CONTRIBUTING)
   - Include relevant context, links, or evidence where possible
@@ -58,8 +57,8 @@ Report it confidentially via:
 ### Enforcement & Accountability
 
 Project maintainers are responsible for enforcing this Code of Conduct.
-Depending on severity and impact, actions may include:
 
+Depending on severity and impact, actions may include:
 - Warning : private notice with guidance.
 - Temporary restrictions : limited participation for a defined period.
 - Temporary suspension : removal from project spaces.
@@ -67,12 +66,10 @@ Depending on severity and impact, actions may include:
 
 Maintainers may skip steps based on severity. Decisions are made to protect the project and community, not to punish individuals.
 
-
 ---
 ### Scope
 
 This Code of Conduct applies to:
-
 - GitHub issues, pull requests, and discussions.
 - Project communication channels (GitHub, WhatsApp, Discord, email).
 - Any situation where an individual is representing AstraGuard AI.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,100 @@
+### Code of Conduct
+---
+### Our Pledge
+
+We, as contributors, maintainers, and participants of AstraGuard AI, pledge to make participation in this project a professional, respectful, and inclusive experience for everyone.
+
+AstraGuard AI is a mission-critical, security-focused open-source system. Collaboration here requires not only technical skill, but responsibility, integrity, and respect for others.
+
+We are committed to fostering an environment that respects the dignity, rights, and contributions of all individuals, regardless of race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other personal characteristics.
+
+---
+### Expected Behavior
+
+   - All participants are expected to:
+
+   - Be respectful, professional, and considerate in communication.
+
+   - Focus discussions on technical merit and project goals.
+
+   - Give and accept clear, direct, and constructive feedback.
+
+   - Take responsibility for mistakes and work to correct them.
+
+   - Respect different experience levels while maintaining high standards.
+
+   - Credit sources appropriately and respect intellectual property.
+
+   - Protect sensitive information and follow responsible security disclosure practices.
+
+   - Act in ways that support a safe, productive, and learning-focused community.
+
+---
+### Unacceptable Behavior
+
+The following behaviors are not tolerated:
+- Harassment — repeated or unwanted behavior after a clear request to stop.
+- Personal or character attacks — insults, demeaning language, or hostility toward individuals or groups.
+- Discrimination or stereotyping based on personal characteristics.
+- Sexualized or inappropriate conduct in any project context.
+- Sharing private or sensitive information without consent.
+- Threats, encouragement of harm, or violence.
+- Bad-faith participation, including deliberate disruption, trolling, or repeated low-effort submissions.
+- Security irresponsibility, including unsafe disclosures or reckless handling of sensitive data.
+
+
+---
+### Additional Restrictions
+
+- Impersonation — pretending to be another person or maintainer.
+- Failure to credit sources or plagiarism.
+- Spam or promotional content unrelated to the project.
+- Misrepresentation of project affiliation or authority.
+
+---
+### Reporting Issues
+
+If you experience or witness behavior that violates this Code of Conduct:
+
+Report it confidentially via:
+
+  - GitHub Issues (if appropriate), or
+
+  - Direct contact with project maintainers (listed in README / CONTRIBUTING)
+
+  - Include relevant context, links, or evidence where possible
+
+---
+### Enforcement & Accountability
+
+Project maintainers are responsible for enforcing this Code of Conduct.
+Depending on severity and impact, actions may include:
+
+- Warning — private notice with guidance.
+- Temporary restrictions — limited participation for a defined period.
+- Temporary suspension — removal from project spaces.
+- Permanent ban — for severe or repeated violations.
+
+Maintainers may skip steps based on severity. Decisions are made to protect the project and community, not to punish individuals.
+
+
+---
+### Scope
+
+This Code of Conduct applies to:
+
+- GitHub issues, pull requests, and discussions.
+- Project communication channels (GitHub, WhatsApp, Discord, email).
+- Any situation where an individual is representing AstraGuard AI.
+
+This Code of Conduct operates alongside `CONTRIBUTING.md`.  
+In case of ambiguity, maintainers may interpret this document in line with AstraGuard AI’s security-first and high-rigor philosophy.
+
+
+---
+### Our Commitment
+AstraGuard AI exists to help contributors learn, collaborate, and build real-world, mission-critical security systems in a respectful and professional environment.
+
+By participating in this project, you agree to uphold these values, engage constructively with others, and contribute in ways that prioritize safety, integrity, and technical excellence.
+
+Thank you for being part of the AstraGuard AI community 🚀🛡️

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,16 +11,16 @@ We are committed to fostering an environment that respects the dignity, rights, 
 ---
 ### Expected Behavior
 
-All participants are expected to:
-   - Be respectful, professional, and considerate in communication.
-   - Focus discussions on technical merit and project goals.
-   - Give and accept clear, direct, and constructive feedback.
-   - Take responsibility for mistakes and work to correct them.
-   - Respect different experience levels while maintaining high standards.
-   - Credit sources appropriately and respect intellectual property.
-   - Protect sensitive information and follow responsible security disclosure practices.
-   - Act in ways that support a safe, productive, and learning-focused community.
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
 
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
 ---
 ### Unacceptable Behavior
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ We are committed to fostering an environment that respects the dignity, rights, 
 ---
 ### Expected Behavior
 
-   - All participants are expected to:
+All participants are expected to:
    - Be respectful, professional, and considerate in communication.
    - Focus discussions on technical merit and project goals.
    - Give and accept clear, direct, and constructive feedback.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -25,8 +25,8 @@ We are committed to fostering an environment that respects the dignity, rights, 
 ### Unacceptable Behavior
 
 The following behaviors are not tolerated:
-- Harassment — repeated or unwanted behavior after a clear request to stop.
-- Personal or character attacks — insults, demeaning language, or hostility toward individuals or groups.
+- Harassment : repeated or unwanted behavior after a clear request to stop.
+- Personal or character attacks : insults, demeaning language, or hostility toward individuals or groups.
 - Discrimination or stereotyping based on personal characteristics.
 - Sexualized or inappropriate conduct in any project context.
 - Sharing private or sensitive information without consent.
@@ -38,7 +38,7 @@ The following behaviors are not tolerated:
 ---
 ### Additional Restrictions
 
-- Impersonation — pretending to be another person or maintainer.
+- Impersonation : pretending to be another person or maintainer.
 - Failure to credit sources or plagiarism.
 - Spam or promotional content unrelated to the project.
 - Misrepresentation of project affiliation or authority.
@@ -60,10 +60,10 @@ Report it confidentially via:
 Project maintainers are responsible for enforcing this Code of Conduct.
 Depending on severity and impact, actions may include:
 
-- Warning — private notice with guidance.
-- Temporary restrictions — limited participation for a defined period.
-- Temporary suspension — removal from project spaces.
-- Permanent ban — for severe or repeated violations.
+- Warning : private notice with guidance.
+- Temporary restrictions : limited participation for a defined period.
+- Temporary suspension : removal from project spaces.
+- Permanent ban : for severe or repeated violations.
 
 Maintainers may skip steps based on severity. Decisions are made to protect the project and community, not to punish individuals.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,21 +12,13 @@ We are committed to fostering an environment that respects the dignity, rights, 
 ### Expected Behavior
 
    - All participants are expected to:
-
    - Be respectful, professional, and considerate in communication.
-
    - Focus discussions on technical merit and project goals.
-
    - Give and accept clear, direct, and constructive feedback.
-
    - Take responsibility for mistakes and work to correct them.
-
    - Respect different experience levels while maintaining high standards.
-
    - Credit sources appropriately and respect intellectual property.
-
    - Protect sensitive information and follow responsible security disclosure practices.
-
    - Act in ways that support a safe, productive, and learning-focused community.
 
 ---
@@ -59,9 +51,7 @@ If you experience or witness behavior that violates this Code of Conduct:
 Report it confidentially via:
 
   - GitHub Issues (if appropriate), or
-
   - Direct contact with project maintainers (listed in README / CONTRIBUTING)
-
   - Include relevant context, links, or evidence where possible
 
 ---


### PR DESCRIPTION
This PR introduces a formal CODE_OF_CONDUCT.md for AstraGuard AI to clearly define community standards, contributor expectations, and enforcement procedures.

AstraGuard AI is a public, security-critical, ECWoC ’26 featured project with contributors across frontend, backend, AI/ML, and security domains. A dedicated Code of Conduct helps ensure collaboration remains respectful, professional, and safe as the project grows.

Closes issue #104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a standalone Code of Conduct defining the community pledge, expected and unacceptable behaviors, additional restrictions, reporting procedures, enforcement and accountability, and scope.
  * Clarifies applicability to issues, pull requests, discussions, and project channels to promote respectful, security-minded collaboration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->