### PR TITLE
Implement Keyboard Shortcut Manager: Cmd+K, Tabs, Replay, Uplink feat issue #229

### DIFF
--- a/frontend/mission-components/app/components/ui/CommandPalette.tsx
+++ b/frontend/mission-components/app/components/ui/CommandPalette.tsx
@@ -1,0 +1,118 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+interface Props {
+    isOpen: boolean;
+    onClose: () => void;
+    onNav: (tab: 'mission' | 'systems' | 'chaos' | 'uplink') => void;
+}
+
+export const CommandPalette: React.FC<Props> = ({ isOpen, onClose, onNav }) => {
+    const [query, setQuery] = useState('');
+    const [selectedIndex, setSelectedIndex] = useState(0);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const commands = [
+        { id: 'mission', label: 'Go to Mission Control', action: () => onNav('mission'), shortcut: '1' },
+        { id: 'systems', label: 'Go to Systems Overview', action: () => onNav('systems'), shortcut: '2' },
+        { id: 'chaos', label: 'Go to Chaos Engineering', action: () => onNav('chaos'), shortcut: '3' },
+        { id: 'uplink', label: 'Go to Uplink Terminal', action: () => onNav('uplink'), shortcut: '4' },
+    ];
+
+    const filtered = commands.filter(c =>
+        c.label.toLowerCase().includes(query.toLowerCase())
+    );
+
+    useEffect(() => {
+        if (isOpen) {
+            // Reset state when opening
+            setQuery('');
+            setSelectedIndex(0);
+            setTimeout(() => inputRef.current?.focus(), 50);
+        }
+    }, [isOpen]);
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (!isOpen) return;
+
+            if (e.key === 'Escape') {
+                onClose();
+            } else if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                setSelectedIndex(prev => (prev + 1) % filtered.length);
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                setSelectedIndex(prev => (prev - 1 + filtered.length) % filtered.length);
+            } else if (e.key === 'Enter') {
+                e.preventDefault();
+                const cmd = filtered[selectedIndex];
+                if (cmd) {
+                    cmd.action();
+                    onClose();
+                }
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [isOpen, filtered, selectedIndex, onClose]);
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-start justify-center pt-[20vh] bg-black/60 backdrop-blur-sm animate-in fade-in duration-200" onClick={onClose}>
+            <div
+                className="w-full max-w-lg bg-black border border-slate-700/50 rounded-xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200"
+                onClick={e => e.stopPropagation()}
+            >
+                <div className="flex items-center border-b border-slate-800 p-3">
+                    <span className="text-slate-500 mr-3">🔍</span>
+                    <input
+                        ref={inputRef}
+                        type="text"
+                        className="flex-1 bg-transparent text-white placeholder-slate-500 outline-none h-6 font-mono text-sm"
+                        placeholder="Type a command..."
+                        value={query}
+                        onChange={e => {
+                            setQuery(e.target.value);
+                            setSelectedIndex(0);
+                        }}
+                    />
+                    <kbd className="hidden sm:inline-block px-2 py-0.5 text-[10px] font-mono text-slate-500 bg-slate-900 border border-slate-700 rounded-md">ESC</kbd>
+                </div>
+
+                <div className="max-h-[300px] overflow-y-auto p-2">
+                    {filtered.map((cmd, index) => (
+                        <button
+                            key={cmd.id}
+                            className={`w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm font-mono transition-colors ${index === selectedIndex ? 'bg-indigo-600 text-white' : 'text-slate-300 hover:bg-slate-800'
+                                }`}
+                            onClick={() => {
+                                cmd.action();
+                                onClose();
+                            }}
+                            onMouseEnter={() => setSelectedIndex(index)}
+                        >
+                            <span>{cmd.label}</span>
+                            {cmd.shortcut && (
+                                <span className={`text-xs opacity-50 ${index === selectedIndex ? 'text-white' : 'text-slate-500'}`}>
+                                    {cmd.shortcut}
+                                </span>
+                            )}
+                        </button>
+                    ))}
+                    {filtered.length === 0 && (
+                        <div className="p-4 text-center text-slate-500 font-mono text-sm">
+                            No commands found.
+                        </div>
+                    )}
+                </div>
+
+                <div className="bg-slate-950 border-t border-slate-800 p-2 text-[10px] text-slate-600 font-mono flex gap-3 px-4">
+                    <span>↑↓ to navigate</span>
+                    <span>↵ to select</span>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/frontend/mission-components/app/components/uplink/CommandTerminal.tsx
+++ b/frontend/mission-components/app/components/uplink/CommandTerminal.tsx
@@ -15,6 +15,14 @@ export const CommandTerminal: React.FC = () => {
     const [input, setInput] = useState('');
     const [isProcessing, setIsProcessing] = useState(false);
     const scrollRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    // Focus handling
+    useEffect(() => {
+        const handleFocus = () => inputRef.current?.focus();
+        window.addEventListener('focus-terminal', handleFocus);
+        return () => window.removeEventListener('focus-terminal', handleFocus);
+    }, []);
 
     const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
         setInput(e.target.value);
@@ -125,6 +133,7 @@ export const CommandTerminal: React.FC = () => {
             <div className="flex items-center gap-2 text-green-400 border-t border-green-900/30 pt-2 relative z-20">
                 <span className="text-green-600 font-bold whitespace-nowrap">user@astraguard:~$</span>
                 <input
+                    ref={inputRef}
                     type="text"
                     value={input}
                     onChange={handleInput}

--- a/frontend/mission-components/app/dashboard/page.tsx
+++ b/frontend/mission-components/app/dashboard/page.tsx
@@ -18,15 +18,35 @@ import { LoadingSkeleton } from '../components/ui/LoadingSkeleton';
 import { TransitionWrapper } from '../components/ui/TransitionWrapper';
 import { MobileNavHamburger } from '../components/ui/MobileNavHamburger';
 import { DesktopTabNav } from '../components/dashboard/DesktopTabNav';
+import { CommandPalette } from '../components/ui/CommandPalette';
+import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 
 const DashboardContent: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'mission' | 'systems' | 'chaos' | 'uplink'>('mission');
   const [selectedAnomalyForAnalysis, setSelectedAnomalyForAnalysis] = useState<AnomalyEvent | null>(null);
-  const { isConnected } = useDashboard();
+  const { isConnected, togglePlay, isReplayMode } = useDashboard();
   const mission = dashboardData.mission as MissionState;
+  const [showPalette, setShowPalette] = useState(false);
+
+  // Keyboard Shortcuts
+  useKeyboardShortcuts({
+    onTabChange: setActiveTab,
+    onTogglePlay: togglePlay,
+    onOpenPalette: () => setShowPalette(true),
+    onFocusTerminal: () => {
+      setActiveTab('uplink');
+      // Assuming Terminal takes focus on mount via autoFocus, which it does.
+    },
+    isReplayMode
+  });
 
   return (
     <div className="dashboard-container min-h-screen text-white font-mono antialiased">
+      <CommandPalette
+        isOpen={showPalette}
+        onClose={() => setShowPalette(false)}
+        onNav={setActiveTab}
+      />
       <DashboardHeader data={mission} />
 
       <div className="flex min-h-screen pt-[100px] lg:pt-[80px] flex-col">

--- a/frontend/mission-components/app/hooks/useKeyboardShortcuts.ts
+++ b/frontend/mission-components/app/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,68 @@
+import { useEffect } from 'react';
+
+interface ShortcutsProps {
+    onTabChange: (tab: 'mission' | 'systems' | 'chaos' | 'uplink') => void;
+    onTogglePlay: () => void;
+    onOpenPalette: () => void;
+    onFocusTerminal: () => void;
+    isReplayMode: boolean;
+}
+
+export const useKeyboardShortcuts = ({
+    onTabChange,
+    onTogglePlay,
+    onOpenPalette,
+    onFocusTerminal,
+    isReplayMode
+}: ShortcutsProps) => {
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            // Ignore if in input/textarea (except Cmd+K)
+            if (
+                ['INPUT', 'TEXTAREA'].includes((e.target as HTMLElement).tagName) &&
+                !(e.metaKey && e.key === 'k') && // Cmd+K
+                !(e.ctrlKey && e.key === 'k') // Ctrl+K
+            ) {
+                return;
+            }
+
+            // Command Palette (Cmd+K or Ctrl+K)
+            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+                e.preventDefault();
+                onOpenPalette();
+                return;
+            }
+
+            // Tab Switching (1-4)
+            if (!e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+                switch (e.key) {
+                    case '1':
+                        onTabChange('mission');
+                        break;
+                    case '2':
+                        onTabChange('systems');
+                        break;
+                    case '3':
+                        onTabChange('chaos');
+                        break;
+                    case '4':
+                        onTabChange('uplink');
+                        break;
+                    case ' ': // Space: Toggle Replay
+                        if (isReplayMode) {
+                            e.preventDefault();
+                            onTogglePlay();
+                        }
+                        break;
+                    case '/': // Slash: Focus Terminal
+                        e.preventDefault();
+                        onFocusTerminal();
+                        break;
+                }
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [onTabChange, onTogglePlay, onOpenPalette, onFocusTerminal, isReplayMode]);
+};


### PR DESCRIPTION
I have implemented the Keyboard Shortcut Manager!

New Shortcuts:

Cmd+K (or Ctrl+K): Open Command Palette to jump between views.
1-4: Switch Tabs directly (1: Mission, 2: Systems, 3: Chaos, 4: Uplink).
/: Focus Uplink Terminal (Even if you are on another tab, it switches and focuses input).
Space: Toggle Play/Pause in Replay Mode.
feat issue #229 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command palette for quick navigation and command execution.
  * Introduced keyboard shortcuts for improved dashboard control: Cmd/Ctrl+K opens the palette, number keys 1-4 switch between tabs, Space toggles play mode, and Slash focuses the terminal.
  * Enhanced terminal focus management for seamless keyboard interaction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->