### PR TITLE
fix(ci): correct path to requirements.txt in workflows and dockerfile feat issue #259

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,6 +47,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: docker/Dockerfile
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,8 +130,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
-        pip install -r requirements-test.txt
+        pip install -r config/requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install -r config/requirements-test.txt
     
     - name: Wait for Redis
       run: |
@@ -240,8 +240,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
-        pip install -r requirements-test.txt
+        pip install -r config/requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install -r config/requirements-test.txt
     
     - name: Wait for Redis
       run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Copy requirements early for caching
-COPY requirements.txt .
+COPY config/requirements.txt .
 
 # Install Python dependencies with CPU-only torch
 RUN pip install --no-cache-dir \


### PR DESCRIPTION
CI/CD Pipeline Fixed

I resolved the requirements.txt not found error.

Cause: The workflows were looking for requirements.txt in the root directory, but it is located in config/.
Fix: Updated .github/workflows/tests.yml, .github/workflows/ci-cd.yml, and docker/Dockerfile to reference config/requirements.txt.feat issue #259