### PR TITLE
CI/CD Pipeline Fix (Canary) feat issue #259

### DIFF
--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install -r config/requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
         pip install -r requirements-test.txt
     
     - name: Wait for Redis
@@ -109,7 +109,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install -r config/requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
         pip install -r requirements-test.txt
     
     - name: Wait for Redis
@@ -161,7 +161,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install -r config/requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
     
     - name: Create environment file
       run: |

--- a/docs/artifacts/walkthrough.md
+++ b/docs/artifacts/walkthrough.md
@@ -54,3 +54,14 @@ Implemented professional PDF generation needed for incident reporting.
 - **Test**: Open any anomaly. Click the Document icon next to the close button.
 - **Result**: A PDF named `AstraGuard_Report_[ID].pdf` is downloaded.
 - **Check**: Verify "TOP SECRET" headers and correct data values.
+
+## 5. CI/CD Pipeline Configuration
+Fixed persistent build errors related to dependency file paths.
+
+### Changes
+- **Requirements Path**: Updated `config/requirements.txt` references in:
+    - `.github/workflows/tests.yml`
+    - `.github/workflows/ci-cd.yml`
+    - `.github/workflows/canary-deploy.yml`
+    - `docker/Dockerfile`
+- **Result**: Build pipelines now correctly locate dependencies in the `config/` directory.


### PR DESCRIPTION
CI/CD Pipeline Fix (Canary)

I identified remaining incorrect references in canary-deploy.yml.

Fix: Updated canary-deploy.yml to use config/requirements.txt instead of the root path.
Status: Changes pushed to main. This should resolve the persistent error regarding requirements.txt not found.

feat issue #259 