### PR TITLE
Persistent CI/CD Error Resolved  feat issue #259

### DIFF
--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install -r config/requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
-        pip install -r requirements-test.txt
+        pip install -r config/requirements-test.txt
     
     - name: Wait for Redis
       run: |
@@ -110,7 +110,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install -r config/requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
-        pip install -r requirements-test.txt
+        pip install -r config/requirements-test.txt
     
     - name: Wait for Redis
       run: |

--- a/docs/artifacts/walkthrough.md
+++ b/docs/artifacts/walkthrough.md
@@ -64,4 +64,5 @@ Fixed persistent build errors related to dependency file paths.
     - `.github/workflows/ci-cd.yml`
     - `.github/workflows/canary-deploy.yml`
     - `docker/Dockerfile`
-- **Result**: Build pipelines now correctly locate dependencies in the `config/` directory.
+- **Test Requirements**: Updated `config/requirements-test.txt` in workflows.
+- **Result**: Build pipelines now correctly locate all dependency files in the `config/` directory.


### PR DESCRIPTION
Persistent CI/CD Error Resolved

The issue with requirements-test.txt not being found was due to one remaining incorrect reference in canary-deploy.yml.

Action: Corrected requirements-test.txt to config/requirements-test.txt in canary-deploy.yml.
Status: Fix pushed to main.
Verification: All workflow files now correctly point to the configuration directory. CI/CD should pass.
feat issue #259 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to reference test requirements from the config directory.

* **Documentation**
  * Updated documentation to reflect that dependency files are now located in the config directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->