### PR TITLE
linked footer sections

### DIFF
--- a/frontend/sample_landing.html
+++ b/frontend/sample_landing.html
@@ -592,12 +592,12 @@
             <h3 style="color: var(--primary); margin-bottom: 1rem;">🛰️ ASTRAGUARD AI</h3>
             <p style="margin-bottom: 1.5rem;">Securing the Final Frontier with Intelligent Satellite Operations</p>
             <div style="display: flex; justify-content: center; gap: 2rem; flex-wrap: wrap; margin-bottom: 2rem;">
-                <a href="#">Privacy Policy</a>
-                <a href="#">Terms of Service</a>
-                <a href="#">Documentation</a>
-                <a href="#">Blog</a>
-                <a href="#">GitHub</a>
-                <a href="#">Twitter</a>
+                <a href="https://github.com/sr-857/AstraGuard-AI/blob/main/CODE_OF_CONDUCT.md">Privacy Policy</a>
+                <a href="https://github.com/sr-857/AstraGuard-AI/blob/main/CONTRIBUTING.md">Terms of Service</a>
+                <a href="https://github.com/sr-857/AstraGuard-AI/blob/main/README.md">Documentation</a>
+                <a href="https://github.com/sr-857/AstraGuard-AI/blob/main/STARTUP_GUIDE.md">Blog</a>
+                <a href="https://github.com/sr-857/AstraGuard-AI">GitHub</a>
+                <a href="https://www.linkedin.com/in/sr857/">Linkedin</a>
             </div>
             <hr style="border: 1px solid rgba(100, 200, 255, 0.1); margin: 2rem 0;">
             <p>&copy; 2026 AstraGuard AI. All rights reserved. | Built by <a href="https://github.com/purvanshjoshi/AstraGuard-AI">Elite Coders</a></p>


### PR DESCRIPTION
All footer sections have been linked to their respective designations.
Linkedin and github has been linked to your linkedin and github id @sr-857 
documentation: readme file
blog: startup.md
privacy: code of conduct.md file...etc

<img width="499" height="104" alt="image" src="https://github.com/user-attachments/assets/1024965a-623b-4700-9767-1a3cf60acd56" />
<img width="568" height="93" alt="image" src="https://github.com/user-attachments/assets/4c33960d-a51d-4e86-8e03-db97bb308656" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Enterprise footer links from placeholder anchors to external resource URLs for Privacy Policy, Terms of Service, Documentation, Blog, and GitHub.
  * Added LinkedIn social profile link to the footer for expanded connectivity options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->