### PR TITLE
fix: allow frontend lib directory to be tracked feat issue #259

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!frontend/**/lib/
 lib64/
 parts/
 sdist/

--- a/frontend/as_lp/lib/utils.ts
+++ b/frontend/as_lp/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
I have resolved the Next.js remote build error.

Issue: The error Module not found: Can't resolve '@/lib/utils' occurred because frontend/as_lp/lib/utils.ts was being ignored by the root .gitignore (which ignored lib/ entirely), preventing it from being pushed to GitHub.

Fix:

Updated .gitignore to explicitly allow frontend/**/lib/ directories.
Added and committed frontend/as_lp/lib/utils.ts to the repository. 
feat issue #259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Git configuration to enable library directory tracking in frontend development
  * Added internal styling utility to support consistent component styling across the application

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->