### PR TITLE
Implement 3D Ground Station Mapping & Weather-Responsive Communication beam feat issue #291

### DIFF
--- a/frontend/mission-components/app/context/DashboardContext.tsx
+++ b/frontend/mission-components/app/context/DashboardContext.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, ReactNode, useState, useEffect } from 'react';
 import { TelemetryState, WSMessage } from '../types/websocket';
 import { useDashboardWebSocket } from '../hooks/useDashboardWebSocket';
+import { GroundStation, RemediationScript, RemediationStep } from '../types/dashboard';
 
 export interface Annotation {
     id: string;
@@ -17,21 +18,6 @@ export interface Operator {
     name: string;
     avatar: string;
     activePanel: string;
-}
-
-export interface RemediationStep {
-    id: string;
-    command: string;
-    description: string;
-    status: 'pending' | 'executing' | 'completed' | 'failed';
-}
-
-export interface RemediationScript {
-    id: string;
-    anomalyId: string;
-    steps: RemediationStep[];
-    status: 'proposed' | 'authorized' | 'executing' | 'completed';
-    createdAt: string;
 }
 
 interface ContextValue {
@@ -57,6 +43,8 @@ interface ContextValue {
     proposeRemediation: (anomalyId: string) => void;
     authorizeRemediation: (id: string) => void;
     cancelRemediation: () => void;
+    // Ground Stations
+    groundStations: GroundStation[];
 }
 
 const DashboardContext = createContext<ContextValue | undefined>(undefined);
@@ -71,6 +59,12 @@ export const DashboardProvider: React.FC<{ children: ReactNode }> = ({ children 
         { id: '3', name: 'KAPPA', avatar: 'K', activePanel: 'Chaos Engine' },
     ]);
     const [activeRemediation, setActiveRemediation] = useState<RemediationScript | null>(null);
+    const [groundStations] = useState<GroundStation[]>([
+        { id: 'gs-1', name: 'Svalbard-A', lat: 78.22, lng: 15.65, weather: 'Clear', signalQuality: 0.98, connectedSatelliteId: 'SAT-01' },
+        { id: 'gs-2', name: 'Kourou-Prime', lat: 5.16, lng: -52.64, weather: 'Rain', signalQuality: 0.65, connectedSatelliteId: 'SAT-02' },
+        { id: 'gs-3', name: 'Canberra-Deep', lat: -35.28, lng: 149.13, weather: 'Clear', signalQuality: 0.95, connectedSatelliteId: 'SAT-03' },
+        { id: 'gs-4', name: 'Haruna-Station', lat: 36.47, lng: 138.92, weather: 'Storm', signalQuality: 0.42, connectedSatelliteId: 'SAT-01' },
+    ]);
 
     // Add Annotation
     const addAnnotation = (note: Omit<Annotation, 'id' | 'timestamp'>) => {
@@ -166,7 +160,8 @@ export const DashboardProvider: React.FC<{ children: ReactNode }> = ({ children 
         activeRemediation,
         proposeRemediation,
         authorizeRemediation,
-        cancelRemediation
+        cancelRemediation,
+        groundStations
     };
 
     return (

--- a/frontend/mission-components/app/mocks/dashboard.json
+++ b/frontend/mission-components/app/mocks/dashboard.json
@@ -100,6 +100,44 @@
         "isActive": false
       }
     ],
-    "anomalies": []
+    "anomalies": [],
+    "groundStations": [
+      {
+        "id": "gs-1",
+        "name": "Svalbard-A",
+        "lat": 78.22,
+        "lng": 15.65,
+        "weather": "Clear",
+        "signalQuality": 0.98,
+        "connectedSatelliteId": "sat-1"
+      },
+      {
+        "id": "gs-2",
+        "name": "Kourou-Prime",
+        "lat": 5.16,
+        "lng": -52.64,
+        "weather": "Rain",
+        "signalQuality": 0.65,
+        "connectedSatelliteId": "sat-2"
+      },
+      {
+        "id": "gs-3",
+        "name": "Canberra-Deep",
+        "lat": -35.28,
+        "lng": 149.13,
+        "weather": "Clear",
+        "signalQuality": 0.95,
+        "connectedSatelliteId": "sat-3"
+      },
+      {
+        "id": "gs-4",
+        "name": "Haruna-Station",
+        "lat": 36.47,
+        "lng": 138.92,
+        "weather": "Storm",
+        "signalQuality": 0.42,
+        "connectedSatelliteId": "sat-1"
+      }
+    ]
   }
 }

--- a/frontend/mission-components/app/types/dashboard.ts
+++ b/frontend/mission-components/app/types/dashboard.ts
@@ -11,6 +11,21 @@ export interface Satellite {
   signalStrength: number;
 }
 
+export interface RemediationStep {
+  id: string;
+  command: string;
+  description: string;
+  status: 'pending' | 'executing' | 'completed' | 'failed';
+}
+
+export interface RemediationScript {
+  id: string;
+  anomalyId: string;
+  steps: RemediationStep[];
+  status: 'proposed' | 'authorized' | 'executing' | 'completed';
+  createdAt: string;
+}
+
 export interface MissionPhase {
   name: string;
   status: 'complete' | 'active' | 'pending';
@@ -32,6 +47,16 @@ export interface AnomalyEvent {
   analysisStatus?: 'pending' | 'completed' | 'failed';
 }
 
+export interface GroundStation {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  weather: 'Clear' | 'Rain' | 'Storm' | 'Clouds';
+  signalQuality: number; // 0 to 1
+  connectedSatelliteId?: string;
+}
+
 export interface MissionState {
   name: string;
   phase: string;
@@ -41,4 +66,5 @@ export interface MissionState {
   satellites: Satellite[];
   phases: MissionPhase[];
   anomalies: AnomalyEvent[];
+  groundStations: GroundStation[];
 }


### PR DESCRIPTION
I have successfully implemented the Ground Station Signal & Weather Overlay!

Highlights:

3D Ground Stations: You can now see ground station markers mapped globally on the 3D Digital Twin.
Weather-Aware Beams: Communication arcs change their color and pattern (Solid Green vs. Dashed Amber) based on the local weather at the station.
Live Interference Visualization: Stations in "Storm" or "Rain" zones show interference pulses and degraded signal quality in their hover tooltips.
All 3D visualization logic is now live in the OrbitMap. 
feat issue #291 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ground stations now displayed dynamically on the orbit map.
  * Weather-aware visual styling for stations and connections based on weather conditions (Clear, Rain, Storm).
  * Signal connections visualized between satellites and ground stations.
  * Weather and signal state indicators displayed for each station.
  * Enhanced overlay UI showing signal status and connected station count.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->