### PR TITLE
feat: Add Ground Station Dynamic Ping-Map for network topology visualization feat issue #313

### DIFF
--- a/frontend/mission-components/app/components/groundStation/GroundStationPanel.tsx
+++ b/frontend/mission-components/app/components/groundStation/GroundStationPanel.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import { motion } from 'framer-motion';
+import { Radio, Activity, Wifi, WifiOff, RefreshCw } from 'lucide-react';
+import { GroundStation, StationStatus } from '../../types/groundStation';
+
+interface GroundStationPanelProps {
+    groundStations: GroundStation[];
+    activeStation: GroundStation | null;
+    onSwitchStation: (stationId: string) => void;
+}
+
+export const GroundStationPanel: React.FC<GroundStationPanelProps> = ({
+    groundStations,
+    activeStation,
+    onSwitchStation,
+}) => {
+    const getStatusColor = (status: StationStatus) => {
+        switch (status) {
+            case StationStatus.ACTIVE:
+                return 'text-green-400 border-green-500/50';
+            case StationStatus.SATURATED:
+                return 'text-yellow-400 border-yellow-500/50';
+            case StationStatus.SWITCHING:
+                return 'text-cyan-400 border-cyan-500/50';
+            case StationStatus.OFFLINE:
+                return 'text-red-400 border-red-500/50';
+        }
+    };
+
+    const getLatencyColor = (latency: number) => {
+        if (latency < 60) return 'text-green-400';
+        if (latency < 100) return 'text-yellow-400';
+        return 'text-red-400';
+    };
+
+    const getStatusIcon = (status: StationStatus) => {
+        switch (status) {
+            case StationStatus.ACTIVE:
+                return <Wifi className="w-4 h-4" />;
+            case StationStatus.SATURATED:
+                return <Activity className="w-4 h-4" />;
+            case StationStatus.SWITCHING:
+                return <RefreshCw className="w-4 h-4 animate-spin" />;
+            case StationStatus.OFFLINE:
+                return <WifiOff className="w-4 h-4" />;
+        }
+    };
+
+    return (
+        <motion.div
+            initial={{ opacity: 0, x: -20 }}
+            animate={{ opacity: 1, x: 0 }}
+            className="fixed left-6 bottom-24 z-50 w-80"
+        >
+            <div className="bg-black/80 backdrop-blur-xl border-2 border-white/10 rounded-xl overflow-hidden">
+                {/* Header */}
+                <div className="p-4 border-b border-white/10 bg-gradient-to-r from-cyan-500/10 to-blue-500/10">
+                    <div className="flex items-center gap-2">
+                        <Radio className="w-5 h-5 text-cyan-400" />
+                        <h3 className="text-sm font-bold text-white uppercase tracking-wider">
+                            Ground Stations
+                        </h3>
+                    </div>
+                </div>
+
+                {/* Stations List */}
+                <div className="max-h-96 overflow-y-auto p-3 space-y-2">
+                    {groundStations.map((station) => (
+                        <motion.div
+                            key={station.id}
+                            className={`p-3 rounded-lg border-2 ${station.isActive
+                                    ? 'bg-cyan-500/10 border-cyan-500/50'
+                                    : 'bg-white/5 border-white/10'
+                                } transition-all`}
+                            whileHover={{ scale: 1.02 }}
+                        >
+                            <div className="flex items-start justify-between mb-2">
+                                <div>
+                                    <div className="flex items-center gap-2">
+                                        <h4 className="text-sm font-bold text-white">{station.name}</h4>
+                                        {station.isActive && (
+                                            <span className="px-2 py-0.5 bg-cyan-500/20 border border-cyan-500/50 rounded text-[10px] text-cyan-400 font-bold uppercase">
+                                                Active
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="text-xs text-white/60">{station.location}</p>
+                                </div>
+                                <div className={`${getStatusColor(station.status)}`}>
+                                    {getStatusIcon(station.status)}
+                                </div>
+                            </div>
+
+                            {/* Metrics */}
+                            <div className="grid grid-cols-2 gap-2 mb-2">
+                                <div>
+                                    <p className="text-[10px] text-white/60 uppercase tracking-widest">Bandwidth</p>
+                                    <p className="text-sm font-bold text-white">{station.bandwidth} Mbps</p>
+                                </div>
+                                <div>
+                                    <p className="text-[10px] text-white/60 uppercase tracking-widest">Latency</p>
+                                    <p className={`text-sm font-bold ${getLatencyColor(station.latency)}`}>
+                                        {station.latency}ms
+                                    </p>
+                                </div>
+                            </div>
+
+                            {/* Switch Button */}
+                            {!station.isActive && station.status !== StationStatus.OFFLINE && (
+                                <button
+                                    onClick={() => onSwitchStation(station.id)}
+                                    disabled={station.status === StationStatus.SWITCHING}
+                                    className="w-full px-3 py-1.5 bg-cyan-500/20 hover:bg-cyan-500/30 border border-cyan-500/50 rounded text-xs text-cyan-400 font-bold uppercase tracking-wider transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                >
+                                    {station.status === StationStatus.SWITCHING ? 'Switching...' : 'Switch to This'}
+                                </button>
+                            )}
+                        </motion.div>
+                    ))}
+                </div>
+            </div>
+        </motion.div>
+    );
+};

--- a/frontend/mission-components/app/context/DashboardContext.tsx
+++ b/frontend/mission-components/app/context/DashboardContext.tsx
@@ -13,6 +13,8 @@ import { useDebrisTracking } from '../hooks/useDebrisTracking';
 import { IncidentPlaybook, StepStatus } from '../types/playbook';
 import { BiometricData } from '../types/biometric';
 import { useBiometricTracking } from '../hooks/useBiometricTracking';
+import { GroundStation } from '../types/groundStation';
+import { useGroundStations } from '../hooks/useGroundStations';
 
 export interface Annotation {
     id: string;
@@ -97,6 +99,10 @@ interface ContextValue {
     isAutoPilotActive: boolean;
     enableAutoPilot: () => void;
     disableAutoPilot: () => void;
+    // Ground Stations
+    groundStations: GroundStation[];
+    activeStation: GroundStation | null;
+    switchStation: (stationId: string) => void;
 }
 
 const DashboardContext = createContext<ContextValue | undefined>(undefined);
@@ -193,6 +199,9 @@ export const DashboardProvider: React.FC<{ children: ReactNode }> = ({ children 
         setIsAutoPilotActive(false);
         console.log('Auto-pilot disabled');
     };
+
+    // Ground Station State
+    const { groundStations, activeStation, switchStation } = useGroundStations();
 
     const unlockAchievement = (id: string) => {
         setAchievements(prev => {
@@ -449,6 +458,9 @@ export const DashboardProvider: React.FC<{ children: ReactNode }> = ({ children 
         isAutoPilotActive,
         enableAutoPilot,
         disableAutoPilot,
+        groundStations,
+        activeStation,
+        switchStation,
     };
 
     return (

--- a/frontend/mission-components/app/dashboard/page.tsx
+++ b/frontend/mission-components/app/dashboard/page.tsx
@@ -44,11 +44,12 @@ import { BiometricPulse } from '../components/biometric/BiometricPulse';
 import { BiometricHUD } from '../components/biometric/BiometricHUD';
 import { HighContrastOverlay } from '../components/biometric/HighContrastOverlay';
 import { AutoPilotProposal } from '../components/biometric/AutoPilotProposal';
+import { GroundStationPanel } from '../components/groundStation/GroundStationPanel';
 
 const DashboardContent: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'mission' | 'systems' | 'chaos' | 'uplink' | 'vault' | 'diagnostics'>('mission');
   const [selectedAnomalyForAnalysis, setSelectedAnomalyForAnalysis] = useState<AnomalyEvent | null>(null);
-  const { isConnected, togglePlay, isReplayMode, isBattleMode, setBattleMode, spaceWeather, distortionIntensity, isGeomagneticStorm, executeSystemReset, debrisObjects, closestDebris, proximityLevel, activePlaybook, setActivePlaybook, biometricData, incrementMissedAlerts, resetMissedAlerts, isAutoPilotActive, enableAutoPilot, disableAutoPilot } = useDashboard();
+  const { isConnected, togglePlay, isReplayMode, isBattleMode, setBattleMode, spaceWeather, distortionIntensity, isGeomagneticStorm, executeSystemReset, debrisObjects, closestDebris, proximityLevel, activePlaybook, setActivePlaybook, biometricData, incrementMissedAlerts, resetMissedAlerts, isAutoPilotActive, enableAutoPilot, disableAutoPilot, groundStations, activeStation, switchStation } = useDashboard();
   const [showSpaceWeatherAlert, setShowSpaceWeatherAlert] = useState(false);
   const [isRedPhoneCoverOpen, setIsRedPhoneCoverOpen] = useState(false);
   const [showProximityAlert, setShowProximityAlert] = useState(true);
@@ -211,6 +212,13 @@ const DashboardContent: React.FC = () => {
 
       {/* Panel Highlighting */}
       <PanelHighlight targetPanelId={highlightedPanel} />
+
+      {/* Ground Station Panel */}
+      <GroundStationPanel
+        groundStations={groundStations}
+        activeStation={activeStation}
+        onSwitchStation={switchStation}
+      />
 
       <div className="flex min-h-screen pt-[100px] lg:pt-[80px] flex-col">
         <nav className="sticky top-[100px] lg:top-[80px] z-20 bg-black/80 backdrop-blur-xl border-b border-teal-500/30 px-6 flex flex-col md:flex-row md:items-center justify-between flex-shrink-0 mb-4" role="tablist">

--- a/frontend/mission-components/app/hooks/useGroundStations.ts
+++ b/frontend/mission-components/app/hooks/useGroundStations.ts
@@ -1,0 +1,132 @@
+import { useState, useEffect, useCallback } from 'react';
+import { GroundStation, StationStatus } from '../types/groundStation';
+
+interface UseGroundStationsReturn {
+    groundStations: GroundStation[];
+    activeStation: GroundStation | null;
+    switchStation: (stationId: string) => void;
+}
+
+const INITIAL_STATIONS: GroundStation[] = [
+    {
+        id: 'svalbard',
+        name: 'Svalbard',
+        location: 'Norway',
+        coordinates: { lat: 78.2232, lon: 15.6267, alt: 0.5 },
+        bandwidth: 150,
+        latency: 45,
+        status: StationStatus.ACTIVE,
+        isActive: true,
+    },
+    {
+        id: 'mumbai',
+        name: 'Mumbai',
+        location: 'India',
+        coordinates: { lat: 19.0760, lon: 72.8777, alt: 0.01 },
+        bandwidth: 80,
+        latency: 120,
+        status: StationStatus.SATURATED,
+        isActive: false,
+    },
+    {
+        id: 'alaska',
+        name: 'Alaska',
+        location: 'USA',
+        coordinates: { lat: 64.2008, lon: -149.4937, alt: 0.3 },
+        bandwidth: 120,
+        latency: 60,
+        status: StationStatus.ACTIVE,
+        isActive: false,
+    },
+    {
+        id: 'santiago',
+        name: 'Santiago',
+        location: 'Chile',
+        coordinates: { lat: -33.4489, lon: -70.6693, alt: 0.5 },
+        bandwidth: 100,
+        latency: 85,
+        status: StationStatus.ACTIVE,
+        isActive: false,
+    },
+];
+
+export const useGroundStations = (): UseGroundStationsReturn => {
+    const [groundStations, setGroundStations] = useState<GroundStation[]>(INITIAL_STATIONS);
+    const [activeStation, setActiveStation] = useState<GroundStation | null>(
+        INITIAL_STATIONS.find((s) => s.isActive) || null
+    );
+
+    const switchStation = useCallback((stationId: string) => {
+        setGroundStations((prev) =>
+            prev.map((station) => ({
+                ...station,
+                isActive: station.id === stationId,
+                status:
+                    station.id === stationId
+                        ? StationStatus.SWITCHING
+                        : station.status === StationStatus.ACTIVE
+                            ? StationStatus.ACTIVE
+                            : station.status,
+            }))
+        );
+
+        // Simulate switching delay
+        setTimeout(() => {
+            setGroundStations((prev) =>
+                prev.map((station) => ({
+                    ...station,
+                    status:
+                        station.id === stationId
+                            ? StationStatus.ACTIVE
+                            : station.status === StationStatus.SWITCHING
+                                ? StationStatus.ACTIVE
+                                : station.status,
+                }))
+            );
+
+            const newActiveStation = groundStations.find((s) => s.id === stationId) || null;
+            setActiveStation(newActiveStation);
+        }, 2000);
+    }, [groundStations]);
+
+    // Simulate bandwidth and latency fluctuations
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setGroundStations((prev) =>
+                prev.map((station) => {
+                    // Random fluctuations
+                    const bandwidthChange = (Math.random() - 0.5) * 20;
+                    const latencyChange = (Math.random() - 0.5) * 10;
+
+                    const newBandwidth = Math.max(50, Math.min(200, station.bandwidth + bandwidthChange));
+                    const newLatency = Math.max(30, Math.min(150, station.latency + latencyChange));
+
+                    // Determine status based on metrics
+                    let newStatus = station.status;
+                    if (station.status !== StationStatus.SWITCHING && station.status !== StationStatus.OFFLINE) {
+                        if (newBandwidth < 70 || newLatency > 130) {
+                            newStatus = StationStatus.SATURATED;
+                        } else {
+                            newStatus = StationStatus.ACTIVE;
+                        }
+                    }
+
+                    return {
+                        ...station,
+                        bandwidth: Math.round(newBandwidth),
+                        latency: Math.round(newLatency),
+                        status: newStatus,
+                    };
+                })
+            );
+        }, 2000); // Update every 2 seconds
+
+        return () => clearInterval(interval);
+    }, []);
+
+    return {
+        groundStations,
+        activeStation,
+        switchStation,
+    };
+};

--- a/frontend/mission-components/app/types/groundStation.ts
+++ b/frontend/mission-components/app/types/groundStation.ts
@@ -1,0 +1,28 @@
+export enum StationStatus {
+    ACTIVE = 'ACTIVE',           // Currently in use
+    SATURATED = 'SATURATED',     // High traffic, degraded performance
+    OFFLINE = 'OFFLINE',         // Not available
+    SWITCHING = 'SWITCHING',     // Transitioning to this station
+}
+
+export interface GroundStation {
+    id: string;
+    name: string;
+    location: string;
+    coordinates: {
+        lat: number;
+        lon: number;
+        alt: number; // Altitude in km
+    };
+    bandwidth: number;      // Mbps
+    latency: number;        // Milliseconds
+    status: StationStatus;
+    isActive: boolean;
+}
+
+export interface UplinkBeam {
+    stationId: string;
+    pulseSpeed: number;     // Speed multiplier based on bandwidth
+    color: string;          // Hex color based on latency
+    isActive: boolean;
+}


### PR DESCRIPTION

- Implemented GroundStation types and StationStatus enum
- Created useGroundStations hook with bandwidth and latency simulation
- Built GroundStationPanel UI for real-time network monitoring
- Integrated station switching functionality
- Added ground station state to DashboardContext
- Rendered GroundStationPanel in the main dashboard

This feature allows operators to monitor uplink/downlink status across global ground stations (Svalbard, Mumbai, Alaska, Santiago), visualize latency/bandwidth, and manually switch stations in case of saturation.
feat issue #313 