### PR TITLE
Fix NameError in api/service.py by defining ChaosRequest model feat issue #259

### DIFF
--- a/api/service.py
+++ b/api/service.py
@@ -822,6 +822,11 @@ async def get_anomaly_history(
     )
 
 
+class ChaosRequest(BaseModel):
+    fault_type: str
+    duration_seconds: int
+
+
 @app.post("/api/v1/chaos/inject")
 async def inject_fault(request: ChaosRequest, api_key: APIKey = Depends(require_permission("admin"))):
     """Trigger a chaos experiment."""


### PR DESCRIPTION
Bug Fix: ChaosRequest NameError
Defined missing 
ChaosRequest
 Pydantic model in 
api/service.py
.
Verified fix by running python -m pytest tests/test_api.py.
feat issue #259 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new admin-only API endpoint to inject faults with customizable fault type and duration parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->