### PR TITLE
Fix ResourceMonitor test failure by reloading secrets cache feat issue #259

### DIFF
--- a/tests/test_resource_monitor.py
+++ b/tests/test_resource_monitor.py
@@ -274,7 +274,10 @@ class TestResourceMonitorSingleton:
         
         # Reset singleton to force reload
         from core import resource_monitor as rm
+        from core.secrets import get_secrets_manager
+        
         rm._resource_monitor = None
+        get_secrets_manager().reload_cache()
         
         monitor = get_resource_monitor()
         


### PR DESCRIPTION
Bug Fix: ResourceMonitor Test Failure
Identified caching issue in 
SecretsManager
 causing 
TestResourceMonitorSingleton
 failure.
Updated 
tests/test_resource_monitor.py
 to reload secrets cache during test setup.
Verified fix by running python -m pytest tests/test_resource_monitor.py.
feat issue #259 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test infrastructure to ensure proper state initialization and refresh during resource monitoring test setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->