### PR TITLE
UI Updates: RedPhoneReset fix/resize, Proximity & Replay toggles, and Default Layer Visibility off feat issue #382

### DIFF
--- a/frontend/mission-components/app/components/controls/RedPhoneReset.tsx
+++ b/frontend/mission-components/app/components/controls/RedPhoneReset.tsx
@@ -144,7 +144,7 @@ export const RedPhoneReset: React.FC<RedPhoneResetProps> = ({ onResetConfirm }) 
                 {/* Cover */}
                 <motion.div
                     drag={!isCoverOpen ? 'y' : false}
-                    dragConstraints={{ top: -100, bottom: 0 }}
+                    dragConstraints={{ top: -60, bottom: 0 }}
                     dragElastic={0.1}
                     onDragEnd={handleCoverDragEnd}
                     style={{
@@ -153,23 +153,21 @@ export const RedPhoneReset: React.FC<RedPhoneResetProps> = ({ onResetConfirm }) 
                         transformOrigin: 'top center',
                         transformStyle: 'preserve-3d',
                     }}
-                    className="absolute inset-0 bg-gradient-to-b from-red-900 to-red-950 border-2 border-red-700 rounded-lg cursor-grab active:cursor-grabbing z-10"
+                    className="absolute inset-0 bg-gradient-to-b from-red-900 to-red-950 border-2 border-red-700 rounded-lg cursor-grab active:cursor-grabbing z-10 w-14 h-14"
                 >
                     <div className="flex items-center justify-center h-full">
-                        <AlertTriangle className="w-8 h-8 text-red-400" />
+                        <AlertTriangle className="w-6 h-6 text-red-400" />
                     </div>
-                    {!isCoverOpen && (
-                        <div className="absolute bottom-2 left-0 right-0 text-center text-[10px] text-red-400 uppercase tracking-widest">
-                            Drag to Open
-                        </div>
-                    )}
                 </motion.div>
 
                 {/* Reset Button */}
-                <div className="relative w-32 h-32 bg-black border-4 border-red-900 rounded-lg overflow-hidden">
+                <div className="relative w-14 h-14 bg-black border-2 border-red-900 rounded-lg overflow-hidden">
                     {isCoverOpen && (
                         <motion.button
-                            {...longPress}
+                            {...(() => {
+                                const { isPressed, progress, ...handlers } = longPress;
+                                return handlers;
+                            })()}
                             initial={{ scale: 0.8, opacity: 0 }}
                             animate={{ scale: 1, opacity: 1 }}
                             className="relative w-full h-full bg-gradient-to-br from-red-600 to-red-800 flex items-center justify-center group"
@@ -183,7 +181,7 @@ export const RedPhoneReset: React.FC<RedPhoneResetProps> = ({ onResetConfirm }) 
                                         r="45%"
                                         fill="none"
                                         stroke="rgba(255, 255, 255, 0.3)"
-                                        strokeWidth="4"
+                                        strokeWidth="2"
                                     />
                                     <motion.circle
                                         cx="50%"
@@ -191,7 +189,7 @@ export const RedPhoneReset: React.FC<RedPhoneResetProps> = ({ onResetConfirm }) 
                                         r="45%"
                                         fill="none"
                                         stroke="#fff"
-                                        strokeWidth="4"
+                                        strokeWidth="2"
                                         strokeDasharray="283"
                                         strokeDashoffset={283 - (283 * longPress.progress) / 100}
                                         strokeLinecap="round"
@@ -201,7 +199,7 @@ export const RedPhoneReset: React.FC<RedPhoneResetProps> = ({ onResetConfirm }) 
 
                             {/* Button Icon */}
                             <Power
-                                className={`w-12 h-12 text-white transition-all ${longPress.isPressed ? 'scale-110' : 'group-hover:scale-105'
+                                className={`w-6 h-6 text-white transition-all ${longPress.isPressed ? 'scale-110' : 'group-hover:scale-105'
                                     }`}
                             />
 
@@ -216,9 +214,9 @@ export const RedPhoneReset: React.FC<RedPhoneResetProps> = ({ onResetConfirm }) 
                     {isCoverOpen && (
                         <button
                             onClick={handleCloseCover}
-                            className="absolute top-2 right-2 text-xs text-red-400 hover:text-red-300 uppercase tracking-wider"
+                            className="absolute -top-1 -right-1 p-1 text-[10px] text-red-400 hover:text-red-300"
                         >
-                            Close
+                            ✕
                         </button>
                     )}
                 </div>

--- a/frontend/mission-components/app/components/mission/LayerControl.tsx
+++ b/frontend/mission-components/app/components/mission/LayerControl.tsx
@@ -7,6 +7,10 @@ interface LayerControlProps {
     onToggleDragMetrics: () => void;
     showBiometrics: boolean;
     onToggleBiometrics: () => void;
+    showProximityAlert: boolean;
+    onToggleProximityAlert: () => void;
+    isReplayMode: boolean;
+    onToggleReplayMode: () => void;
 }
 
 export const LayerControl: React.FC<LayerControlProps> = ({
@@ -15,16 +19,31 @@ export const LayerControl: React.FC<LayerControlProps> = ({
     showDragMetrics,
     onToggleDragMetrics,
     showBiometrics,
-    onToggleBiometrics
+    onToggleBiometrics,
+    showProximityAlert,
+    onToggleProximityAlert,
+    isReplayMode,
+    onToggleReplayMode
 }) => {
     return (
         <div className="fixed top-24 right-24 z-40 flex items-center gap-4">
+            {/* Replay Toggle */}
+            {!isReplayMode && (
+                <button
+                    onClick={onToggleReplayMode}
+                    className="flex items-center gap-2 px-4 py-2 rounded-lg border backdrop-blur-md transition-all bg-black/40 border-white/10 text-slate-400 hover:text-white hover:border-white/30"
+                >
+                    <span className="text-lg">↺</span>
+                    <span className="text-xs font-bold uppercase tracking-wider">Replay Mode</span>
+                </button>
+            )}
+
             {/* Ground Stations Toggle */}
             <button
                 onClick={onToggleGroundStations}
                 className={`flex items-center gap-2 px-4 py-2 rounded-lg border backdrop-blur-md transition-all ${showGroundStations
-                        ? 'bg-cyan-500/20 border-cyan-500 text-cyan-400 shadow-[0_0_15px_rgba(6,182,212,0.3)]'
-                        : 'bg-black/40 border-white/10 text-slate-400 hover:text-white hover:border-white/30'
+                    ? 'bg-cyan-500/20 border-cyan-500 text-cyan-400 shadow-[0_0_15px_rgba(6,182,212,0.3)]'
+                    : 'bg-black/40 border-white/10 text-slate-400 hover:text-white hover:border-white/30'
                     }`}
             >
                 <div className={`w-2 h-2 rounded-full ${showGroundStations ? 'bg-cyan-400 animate-pulse' : 'bg-slate-600'}`} />
@@ -35,8 +54,8 @@ export const LayerControl: React.FC<LayerControlProps> = ({
             <button
                 onClick={onToggleDragMetrics}
                 className={`flex items-center gap-2 px-4 py-2 rounded-lg border backdrop-blur-md transition-all ${showDragMetrics
-                        ? 'bg-orange-500/20 border-orange-500 text-orange-400 shadow-[0_0_15px_rgba(249,115,22,0.3)]'
-                        : 'bg-black/40 border-white/10 text-slate-400 hover:text-white hover:border-white/30'
+                    ? 'bg-orange-500/20 border-orange-500 text-orange-400 shadow-[0_0_15px_rgba(249,115,22,0.3)]'
+                    : 'bg-black/40 border-white/10 text-slate-400 hover:text-white hover:border-white/30'
                     }`}
             >
                 <div className={`w-2 h-2 rounded-full ${showDragMetrics ? 'bg-orange-400 animate-pulse' : 'bg-slate-600'}`} />
@@ -47,12 +66,24 @@ export const LayerControl: React.FC<LayerControlProps> = ({
             <button
                 onClick={onToggleBiometrics}
                 className={`flex items-center gap-2 px-4 py-2 rounded-lg border backdrop-blur-md transition-all ${showBiometrics
-                        ? 'bg-blue-500/20 border-blue-500 text-blue-400 shadow-[0_0_15px_rgba(59,130,246,0.3)]'
-                        : 'bg-black/40 border-white/10 text-slate-400 hover:text-white hover:border-white/30'
+                    ? 'bg-blue-500/20 border-blue-500 text-blue-400 shadow-[0_0_15px_rgba(59,130,246,0.3)]'
+                    : 'bg-black/40 border-white/10 text-slate-400 hover:text-white hover:border-white/30'
                     }`}
             >
                 <div className={`w-2 h-2 rounded-full ${showBiometrics ? 'bg-blue-400 animate-pulse' : 'bg-slate-600'}`} />
                 <span className="text-xs font-bold uppercase tracking-wider">Biometrics</span>
+            </button>
+
+            {/* Proximity Toggle */}
+            <button
+                onClick={onToggleProximityAlert}
+                className={`flex items-center gap-2 px-4 py-2 rounded-lg border backdrop-blur-md transition-all ${showProximityAlert
+                    ? 'bg-red-500/20 border-red-500 text-red-400 shadow-[0_0_15px_rgba(239,68,68,0.3)]'
+                    : 'bg-black/40 border-white/10 text-slate-400 hover:text-white hover:border-white/30'
+                    }`}
+            >
+                <div className={`w-2 h-2 rounded-full ${showProximityAlert ? 'bg-red-400 animate-pulse' : 'bg-slate-600'}`} />
+                <span className="text-xs font-bold uppercase tracking-wider">Proximity</span>
             </button>
         </div>
     );

--- a/frontend/mission-components/app/components/replay/ReplayControls.tsx
+++ b/frontend/mission-components/app/components/replay/ReplayControls.tsx
@@ -22,14 +22,7 @@ export const ReplayControls: React.FC = () => {
     }, [isReplayMode, isPlaying, setReplayProgress]);
 
     if (!isReplayMode) {
-        return (
-            <button
-                onClick={toggleReplayMode}
-                className="px-3 py-1 bg-slate-800 hover:bg-indigo-600 text-slate-300 hover:text-white text-xs font-mono rounded border border-slate-700 transition-colors uppercase tracking-wider flex items-center gap-2"
-            >
-                <span>↺</span> Enter Replay Mode
-            </button>
-        );
+        return null;
     }
 
     return (

--- a/frontend/mission-components/app/dashboard/page.tsx
+++ b/frontend/mission-components/app/dashboard/page.tsx
@@ -51,7 +51,7 @@ import { LayerControl } from '../components/mission/LayerControl';
 const DashboardContent: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'mission' | 'systems' | 'chaos' | 'uplink' | 'vault' | 'diagnostics'>('mission');
   const [selectedAnomalyForAnalysis, setSelectedAnomalyForAnalysis] = useState<AnomalyEvent | null>(null);
-  const { isConnected, togglePlay, isReplayMode, isBattleMode, setBattleMode, spaceWeather, distortionIntensity, isGeomagneticStorm, executeSystemReset, debrisObjects, closestDebris, proximityLevel, activePlaybook, setActivePlaybook, biometricData, incrementMissedAlerts, resetMissedAlerts, isAutoPilotActive, enableAutoPilot, disableAutoPilot, groundStations, activeStation, switchStation, dragPhysics, executeReboost } = useDashboard();
+  const { isConnected, togglePlay, isReplayMode, toggleReplayMode, isBattleMode, setBattleMode, spaceWeather, distortionIntensity, isGeomagneticStorm, executeSystemReset, debrisObjects, closestDebris, proximityLevel, activePlaybook, setActivePlaybook, biometricData, incrementMissedAlerts, resetMissedAlerts, isAutoPilotActive, enableAutoPilot, disableAutoPilot, groundStations, activeStation, switchStation, dragPhysics, executeReboost } = useDashboard();
   const [showSpaceWeatherAlert, setShowSpaceWeatherAlert] = useState(false);
   const [isRedPhoneCoverOpen, setIsRedPhoneCoverOpen] = useState(false);
   const [showProximityAlert, setShowProximityAlert] = useState(true);
@@ -61,9 +61,9 @@ const DashboardContent: React.FC = () => {
   const [showPalette, setShowPalette] = useState(false);
 
   // Layer Visibility State
-  const [showGroundStations, setShowGroundStations] = useState(true);
-  const [showDragMetrics, setShowDragMetrics] = useState(true);
-  const [showBiometrics, setShowBiometrics] = useState(true);
+  const [showGroundStations, setShowGroundStations] = useState(false);
+  const [showDragMetrics, setShowDragMetrics] = useState(false);
+  const [showBiometrics, setShowBiometrics] = useState(false);
 
   // Audio Engine Integration
   const [activeAudio, setActiveAudio] = useState(false);
@@ -200,7 +200,7 @@ const DashboardContent: React.FC = () => {
       <DashboardHeader data={mission} />
 
       {/* Red Phone Reset Button */}
-      <div className="fixed top-6 right-6 z-50">
+      <div className="fixed bottom-6 right-6 z-50">
         <RedPhoneReset onResetConfirm={executeSystemReset} />
       </div>
 
@@ -232,6 +232,10 @@ const DashboardContent: React.FC = () => {
         onToggleDragMetrics={() => setShowDragMetrics(!showDragMetrics)}
         showBiometrics={showBiometrics}
         onToggleBiometrics={() => setShowBiometrics(!showBiometrics)}
+        showProximityAlert={showProximityAlert}
+        onToggleProximityAlert={() => setShowProximityAlert(!showProximityAlert)}
+        isReplayMode={isReplayMode}
+        onToggleReplayMode={toggleReplayMode}
       />
 
       {/* Ground Station Panel */}


### PR DESCRIPTION

Replay Toggle Moved

I have repositioned the Enter Replay Mode button:

Location: It is now in the Layer Control panel (top-right), clearly situated to the left of the "Ground Stn" toggle.
Behavior: Clicking it enters Replay Mode. Once in Replay Mode, the full timeline controls will appear in the navigation bar as before.
feat issue #382 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Proximity Alert toggle control
  * Added Replay Mode toggle control

* **UI/UX Updates**
  * Redesigned reset button with more compact appearance and improved interaction
  * Relocated reset button to bottom-right corner
  * Updated close button with new visual style
  * Removed "Drag to Open" instruction text

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->