### PR TITLE
Fix docker.DockerClient import compatibility issue feat issue #259

### DIFF
--- a/tests/swarm/chaos/chaos_injector.py
+++ b/tests/swarm/chaos/chaos_injector.py
@@ -12,14 +12,17 @@ Extends failure_injector.py with advanced chaos methods:
 import asyncio
 import subprocess
 import time
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional, TYPE_CHECKING
 import docker
+
+if TYPE_CHECKING:
+    from docker.client import DockerClient
 
 
 class ChaosInjectorExtensions:
     """Advanced chaos injection methods for swarm resilience testing."""
     
-    def __init__(self, docker_client: docker.DockerClient = None):
+    def __init__(self, docker_client: Optional["DockerClient"] = None):
         """Initialize chaos injector with docker client."""
         self.docker = docker_client or docker.from_env()
         self.active_chaos = {}  # Track active chaos scenarios

--- a/tests/swarm/e2e/anomaly_injector.py
+++ b/tests/swarm/e2e/anomaly_injector.py
@@ -16,9 +16,12 @@ import asyncio
 import time
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, TYPE_CHECKING
 import docker
 from datetime import datetime
+
+if TYPE_CHECKING:
+    from docker.client import DockerClient
 
 
 class AnomalySeverity(Enum):
@@ -71,7 +74,7 @@ class AnomalyInjector:
     - #413: Safety simulator (blocks unsafe recovery)
     """
     
-    def __init__(self, docker_client: docker.DockerClient, network_name: str = "isl-net"):
+    def __init__(self, docker_client: "DockerClient", network_name: str = "isl-net"):
         """
         Initialize anomaly injector.
         

--- a/tests/swarm/e2e/test_recovery_pipeline.py
+++ b/tests/swarm/e2e/test_recovery_pipeline.py
@@ -18,9 +18,12 @@ Success metrics:
 import asyncio
 import time
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 from enum import Enum
 import docker
+
+if TYPE_CHECKING:
+    from docker.client import DockerClient
 
 from anomaly_injector import AnomalyInjector, AnomalySeverity, AnomalyEvent
 
@@ -88,7 +91,7 @@ class RecoveryPipelineTest:
     - All #397-413 components: Full pipeline
     """
     
-    def __init__(self, docker_client: docker.DockerClient):
+    def __init__(self, docker_client: "DockerClient"):
         """Initialize E2E test suite."""
         self.docker_client = docker_client
         self.anomaly_injector = AnomalyInjector(docker_client)

--- a/tests/swarm/failure_injector.py
+++ b/tests/swarm/failure_injector.py
@@ -15,10 +15,13 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import List, Optional, Callable, Dict, Any
+from typing import List, Optional, Callable, Dict, Any, TYPE_CHECKING
 from enum import Enum
 import subprocess
 import docker
+
+if TYPE_CHECKING:
+    from docker.client import DockerClient
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +65,7 @@ class FailureConfig:
 class FailureInjector:
     """Injects failures into running swarm."""
     
-    def __init__(self, docker_client: Optional[docker.DockerClient] = None):
+    def __init__(self, docker_client: Optional["DockerClient"] = None):
         """Initialize failure injector."""
         self.docker = docker_client or docker.from_env()
         self.active_failures: Dict[str, FailureConfig] = {}


### PR DESCRIPTION
- Replace docker.DockerClient type hints with proper TYPE_CHECKING pattern
- Use TYPE_CHECKING guard to import DockerClient from docker.client
- All 4 files updated: failure_injector, chaos_injector, anomaly_injector, test_recovery_pipeline
- Fixes AttributeError: module 'docker' has no attribute 'DockerClient' in pytest collection

This resolves test collection failures in:
- tests/swarm/chaos
- tests/swarm/e2e
- tests/swarm/integration
- All individual swarm test files

Compatible with docker-py library version handling.
feat issue #259 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal type hint improvements in test infrastructure to enhance code maintainability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->