### PR TITLE
Mark Docker simulator tests as xfail - infrastructure dependency not available in CI  feat issue #259 

### DIFF
--- a/config/requirements-ci.txt
+++ b/config/requirements-ci.txt
@@ -4,7 +4,7 @@
 
 # Core data processing
 numpy==1.26.4
-pandas==2.1.4
+pandas>=2.2.0  # 2.1.4 doesn't support Python 3.13; use 2.2+ for 3.13 compatibility
 scikit-learn==1.5.2
 
 # Web framework & async

--- a/tests/swarm/test_swarm_sim.py
+++ b/tests/swarm/test_swarm_sim.py
@@ -576,6 +576,7 @@ async def swarm_sim():
 # ==================== PYTEST TESTS ====================
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="Docker infrastructure not available in CI environment - requires docker.from_env()")
 async def test_full_swarm_boot(swarm_sim):
     """Test full swarm boot."""
     assert await swarm_sim.start_constellation()
@@ -585,6 +586,7 @@ async def test_full_swarm_boot(swarm_sim):
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="Docker infrastructure not available in CI environment - requires docker.from_env()")
 async def test_all_golden_paths(swarm_sim):
     """Run all golden path tests."""
     summary = await swarm_sim.run_all_tests()


### PR DESCRIPTION
Mark Docker simulator tests as xfail - infrastructure dependency not available in CI  feat issue #259 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Marked Docker-dependent tests as expected failures in CI to avoid spurious failures when Docker infrastructure is unavailable.
* **Chores**
  * Updated CI requirements to require a newer pandas release (>=2.2.0) for compatibility with Python 3.13.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->