### PR TITLE
#474 Prune Method Incorrectly Handles max_age_hours=0

### DIFF
--- a/memory_engine/memory_store.py
+++ b/memory_engine/memory_store.py
@@ -205,6 +205,8 @@ class AdaptiveMemoryStore:
         """
         if max_age_hours < 0:
             raise ValueError("max_age_hours must be non-negative")
+        if max_age_hours == 0:
+            return 0
         with self._lock:
             cutoff = datetime.now() - timedelta(hours=max_age_hours)
             initial_count = len(self.memory)


### PR DESCRIPTION
## Bug Description:

The prune method in the `AdaptiveMemoryStore `class incorrectly handles the case when `max_age_hours`=0. When this value is passed, the `cutoff `timestamp is calculated as `datetime.now()` - timedelta(hours=0), which equals `datetime.now()`. This causes the pruning logic to remove all events because no event's timestamp can be greater than the current time (`event.timestamp` > `cutoff `is False for all events where timestamp <= now). As a result, the memory store is unexpectedly cleared, even for freshly added events.

## Solution:

Added a special case check in the prune method: if max_age_hours == 0, immediately return 0 (indicating no events were pruned). This prevents any pruning when the age limit is set to zero, which logically means no age-based pruning should occur.